### PR TITLE
fix: Problem in the description field when using the MariaDB or MySQL.

### DIFF
--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -10,7 +10,7 @@ import emoji
 from emoji import purely_emoji  # type: ignore
 from fastapi import HTTPException, status
 from pydantic import field_serializer, field_validator
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import UniqueConstraint, Text
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 from langflow.schema import Data
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 class FlowBase(SQLModel):
     name: str = Field(index=True)
-    description: Optional[str] = Field(index=True, nullable=True, default=None)
+    description: Optional[str] = Field(sa_column=Column(Text, index=True, nullable=True, default=None))
     icon: Optional[str] = Field(default=None, nullable=True)
     icon_bg_color: Optional[str] = Field(default=None, nullable=True)
     data: Optional[Dict] = Field(default=None, nullable=True)

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import UniqueConstraint
-from sqlmodel import Field, Relationship, SQLModel
+from sqlalchemy import UniqueConstraint, Text
+from sqlmodel import Field, Relationship, SQLModel, Column
 
 from langflow.services.database.models.flow.model import FlowRead
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class FolderBase(SQLModel):
     name: str = Field(index=True)
-    description: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None, sa_column=Column(Text))
 
 
 class Folder(FolderBase, table=True):  # type: ignore


### PR DESCRIPTION
This pull request addresses an issue where the 'description' fields, defined as str in the SQLModel model, were being created as varchar(255) columns in MariaDB and MySQL databases. This behavior was inconsistent with the expected text data type for these fields.

Changes:

- Modified the data type of the 'description' fields in the SQLModel model to sqlalchemy.Text. This ensures that the corresponding columns in MariaDB and MySQL are created as text columns, allowing for larger text values.
- Note: PostgreSQL is not affected by this change as it does not require a specific size for text columns.

Reasoning:

- The varchar(255) data type imposes a character limit, which may not be sufficient for storing longer descriptions.
- Using the text data type provides more flexibility for storing variable-length text data without size constraints.